### PR TITLE
Fix OTA multiple definition build error

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Settings
-version=1.0.15
+version=1.0.16
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Simple UI webface builder for esp8266/esp32

--- a/src/core/ota.cpp
+++ b/src/core/ota.cpp
@@ -1,0 +1,35 @@
+#include "ota.h"
+
+namespace sets {
+
+bool beginOta(bool ota_flash, bool async) {
+    size_t ota_size = 0;
+    int ota_type = 0;
+
+    if (ota_flash) {
+        ota_type = U_FLASH;
+#ifdef ESP8266
+        ota_size = (size_t)((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000);
+#else
+        ota_size = UPDATE_SIZE_UNKNOWN;
+#endif
+    } else {
+#ifdef ESP8266
+        ota_type = U_FS;
+        close_all_fs();
+#ifndef GH_NO_FS
+        ota_size = (size_t)&_FS_end - (size_t)&_FS_start;
+#endif
+#else
+        ota_type = U_SPIFFS;
+        ota_size = UPDATE_SIZE_UNKNOWN;
+#endif
+    }
+    
+#ifdef ESP8266
+    if (async) Update.runAsync(true);
+#endif
+    return Update.begin(ota_size, ota_type);
+}
+
+}

--- a/src/core/ota.h
+++ b/src/core/ota.h
@@ -12,34 +12,6 @@
 
 namespace sets {
 
-bool beginOta(bool ota_flash = true, bool async = false) {
-    size_t ota_size = 0;
-    int ota_type = 0;
-
-    if (ota_flash) {
-        ota_type = U_FLASH;
-#ifdef ESP8266
-        ota_size = (size_t)((ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000);
-#else
-        ota_size = UPDATE_SIZE_UNKNOWN;
-#endif
-    } else {
-#ifdef ESP8266
-        ota_type = U_FS;
-        close_all_fs();
-#ifndef GH_NO_FS
-        ota_size = (size_t)&_FS_end - (size_t)&_FS_start;
-#endif
-#else
-        ota_type = U_SPIFFS;
-        ota_size = UPDATE_SIZE_UNKNOWN;
-#endif
-    }
-    
-#ifdef ESP8266
-    if (async) Update.runAsync(true);
-#endif
-    return Update.begin(ota_size, ota_type);
-}
+bool beginOta(bool ota_flash = true, bool async = false);
 
 }  // namespace sets


### PR DESCRIPTION
Ошибка сборки при инклуде Settings.h в несколько .cpp файлов
```
Linking .pio\build\4d_systems_esp32s3_gen4_r8n16\firmware.elf
c:/users/denis/.platformio/packages/toolchain-xtensa-esp32s3/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld.exe: .pio/build/4d_systems_esp32s3_gen4_r8n16/src/webgui.cpp.o: in function `sets::beginOta(bool, bool)':
C:\Users\Denis\Documents\PlatformIO\Projects\GyverGUITest/.pio/libdeps/4d_systems_esp32s3_gen4_r8n16/Settings/src/core/ota.h:15: multiple definition of `sets::beginOta(bool, bool)'; .pio/build/4d_systems_esp32s3_gen4_r8n16/src/main.cpp.o:C:\Users\Denis\Documents\PlatformIO\Projects\GyverGUITest/.pio/libdeps/4d_systems_esp32s3_gen4_r8n16/Settings/src/core/ota.h:15: first defined here
collect2.exe: error: ld returned 1 exit status
*** [.pio\build\4d_systems_esp32s3_gen4_r8n16\firmware.elf] Error 1
============================================================================= [FAILED] Took 6.39 seconds =============================================================================
```

### Пример программы:
main.cpp
```cpp
#include <Arduino.h>
#include "webgui.hpp"

void setup() {
  WebGUI.begin();
}

void loop() {
}
```

webgui.hpp
```cpp
#ifndef __WEB_GUI_HPP__
#define __WEB_GUI_HPP__

#include <SettingsAsync.h>

class WebGUIClass : public SettingsAsync
{
public:
    void begin();
};

extern WebGUIClass WebGUI;

#endif /* __WEB_GUI_HPP__ */
```

webgui.cpp

```cpp
#include "webgui.hpp"

void WebGUIClass::begin() {
}

WebGUIClass WebGUI;
```