### PR TITLE
Fix SettingsAsync build error for ESP32

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Settings
-version=1.0.17
+version=1.0.18
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Simple UI webface builder for esp8266/esp32

--- a/src/core/ota.cpp
+++ b/src/core/ota.cpp
@@ -8,7 +8,6 @@
 #include <Updater.h>
 #include <flash_hal.h>
 #else
-#include <Update.h>
 #include <WiFi.h>
 #endif
 

--- a/src/core/ota.h
+++ b/src/core/ota.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ESP8266
+#include <Update.h>
+#endif
+
 namespace sets {
 
 bool beginOta(bool ota_flash = true, bool async = false);


### PR DESCRIPTION
После переноса Update.h из ota.h в ota.cpp не собирается SettingsAsync.h под ESP32 из-за невидимости класса Update  в ota хандлере сервера