### PR TITLE
Built-in file manager's file system customizability

### DIFF
--- a/src/core/fs.h
+++ b/src/core/fs.h
@@ -3,22 +3,45 @@
 #include <FS.h>
 #include <LittleFS.h>
 #include <StringUtils.h>
-
-#define ST_FS LittleFS
+#include <functional>
+#include <type_traits>
 
 namespace sets {
 
 class FSClass {
    public:
+    FSClass() {
+        _fs = &LittleFS;
+
+        _totalBytes = []() -> size_t {
+            return LittleFS.totalBytes();
+        };
+
+        _usedBytes = []() -> size_t {
+            return LittleFS.usedBytes();
+        };
+    }
+
+    template <typename T, typename = typename std::enable_if<std::is_base_of<FS, T>::value>::type>
+    void setFS(
+        T& fs,
+        const std::function<size_t()>& totalBytes,
+        const std::function<size_t()>& usedBytes
+    ) {
+        _fs = &fs;
+        _totalBytes = totalBytes;
+        _usedBytes = usedBytes;
+    }
+
     void listDir(String& str, const char* path, bool withSize = false) {
 #ifdef ESP8266
-        Dir dir = ST_FS.openDir(path);
+        Dir dir = _fs->openDir(path);
         while (dir.next()) {
             if (dir.isDirectory()) {
                 String p(path);
                 p += dir.fileName();
                 p += '/';
-                Dir sdir = ST_FS.openDir(p);
+                Dir sdir = _fs->openDir(p);
                 listDir(str, p.c_str(), withSize);
             }
             if (dir.isFile() && dir.fileName().length()) {
@@ -33,7 +56,7 @@ class FSClass {
         }
 
 #else  // ESP32
-        File root = ST_FS.open(path);
+        File root = _fs->open(path);
         if (!root || !root.isDirectory()) return;
         File file;
         while (file = root.openNextFile()) {
@@ -53,29 +76,29 @@ class FSClass {
     }
 
     bool remove(Text path) {
-        return ST_FS.remove(path.c_str());
+        return _fs->remove(path.c_str());
     }
 
     File openRead(Text path) {
-        return ST_FS.open(path.c_str(), "r");
+        return _fs->open(path.c_str(), "r");
     }
 
     File openWrite(Text path) {
         mkdir(path);
-        return ST_FS.open(path.c_str(), "w");
+        return _fs->open(path.c_str(), "w");
     }
 
     void mkdir(Text tpath) {
 #ifdef ESP32
         Text::Cstr path = tpath.c_str();
-        if (!ST_FS.exists(path)) {
+        if (!_fs->exists(path)) {
             if (strchr(path, '/')) {
                 char* pathStr = strdup(path);
                 if (pathStr) {
                     char* ptr = strchr(pathStr, '/');
                     while (ptr) {
                         *ptr = 0;
-                        ST_FS.mkdir(pathStr);
+                        _fs->mkdir(pathStr);
                         *ptr = '/';
                         ptr = strchr(ptr + 1, '/');
                     }
@@ -94,7 +117,7 @@ class FSClass {
             char* ptr = strrchr(pathStr, '/');
             while (ptr) {
                 *ptr = 0;
-                ST_FS.rmdir(pathStr);
+                _fs->rmdir(pathStr);
                 ptr = strrchr(pathStr, '/');
             }
             free(pathStr);
@@ -106,32 +129,38 @@ class FSClass {
     uint64_t freeSpace() {
 #ifdef ESP8266
         FSInfo64 fs_info;
-        ST_FS.info64(fs_info);
+        _fs->info64(fs_info);
         return fs_info.totalBytes - fs_info.usedBytes;
 #else
-        return ST_FS.totalBytes() - ST_FS.usedBytes();
+        return _totalBytes() - _usedBytes();
 #endif
     }
 
     uint64_t totalSpace() {
 #ifdef ESP8266
         FSInfo64 fs_info;
-        ST_FS.info64(fs_info);
+        _fs->info64(fs_info);
         return fs_info.totalBytes;
 #else
-        return ST_FS.totalBytes();
+        return _totalBytes();
 #endif
     }
 
     uint64_t usedSpace() {
 #ifdef ESP8266
         FSInfo64 fs_info;
-        ST_FS.info64(fs_info);
+        _fs->info64(fs_info);
         return fs_info.usedBytes;
 #else
-        return ST_FS.usedBytes();
+        return _usedBytes();
 #endif
     }
+
+   private:
+    FS* _fs;
+
+    std::function<size_t()> _totalBytes;
+    std::function<size_t()> _usedBytes;
 };
 
 extern FSClass FS;

--- a/src/core/fs.h
+++ b/src/core/fs.h
@@ -14,11 +14,23 @@ class FSClass {
         _fs = &LittleFS;
 
         _totalBytes = []() -> size_t {
+#ifdef ESP8266
+            FSInfo64 fs_info{};
+            LittleFS.info64(fs_info);
+            return fs_info.totalBytes;
+#else
             return LittleFS.totalBytes();
+#endif
         };
 
         _usedBytes = []() -> size_t {
+#ifdef ESP8266
+            FSInfo64 fs_info{};
+            LittleFS.info64(fs_info);
+            return fs_info.usedBytes;
+#else
             return LittleFS.usedBytes();
+#endif
         };
     }
 
@@ -127,33 +139,15 @@ class FSClass {
     }
 
     uint64_t freeSpace() {
-#ifdef ESP8266
-        FSInfo64 fs_info;
-        _fs->info64(fs_info);
-        return fs_info.totalBytes - fs_info.usedBytes;
-#else
         return _totalBytes() - _usedBytes();
-#endif
     }
 
     uint64_t totalSpace() {
-#ifdef ESP8266
-        FSInfo64 fs_info;
-        _fs->info64(fs_info);
-        return fs_info.totalBytes;
-#else
         return _totalBytes();
-#endif
     }
 
     uint64_t usedSpace() {
-#ifdef ESP8266
-        FSInfo64 fs_info;
-        _fs->info64(fs_info);
-        return fs_info.usedBytes;
-#else
         return _usedBytes();
-#endif
     }
 
    private:


### PR DESCRIPTION
Allows to customize file system for the built-in file manager.
To set SD card file system you can do:
```
sets::FS.setFS(
    SD,
    []() -> size_t { return SD.totalBytes(); },
    []() -> size_t { return SD.usedBytes(); }
);
```