### PR TITLE
fixed no work captive portal after wifi reconnect

### DIFF
--- a/src/SettingsAsync.h
+++ b/src/SettingsAsync.h
@@ -129,6 +129,7 @@ class SettingsAsync : public sets::SettingsBase {
 
     void stop() {
         server.end();
+        _dns.stop();
     }
 
     void tick() {


### PR DESCRIPTION
Столкнулся с проблемой, когда захватывающий портал не работал, после переключения между AP и AP_STA режимами. Сейчас делаю небольшой проект умного устройства для HA и решил сделать красивую логику взаимодействия с WiFi. У меня свой менеджер сети, который обрабатывает состояния WiFi и управляет им следующим образом:

1. Если в бд есть wifi creds, то он их берет и пытается подключиться.
2. Если подключение произошло, то срабатывает вызов callback, который останавливает settings и запускает заново.
3. Через Settings уже можно нажать кнопку переключиться на AP, что приведет к отключению (с вызовом callback который отключит settings) от WiFi и включит AP_STA и далее 4.
4. Этот исход запускается как при ручном переключении, так и при отсутствии данных wifi или ошибки подключения. При запуске вызывается тот же callback что и при подключении к WiFi.

Проблема: переключения работали исправно, но при подключении к WiFi точке доступа из режима AP_STA переставал работать захватывающий портал, хотя settings точно перезапускался обратными вызовами. Методом научного втыка был найден злодей - SettingsAsync, который не останавливал DNS, хотя должен был. В SettingsAsync видать просто забыли реализовать, так как в SettingsESP остановка присутствует.

Ну и если изменения будут долго попадать в основную библиотечку можно пользоваться таким взломом, что я делаю и сейчас:

```cpp
template<typename Tag, typename Tag::type M>
struct AccessPrivate {
    friend typename Tag::type get(Tag /*unused*/) { return M; }
};

struct DnsAccess {
    typedef sets::DnsWrapper SettingsAsync::*type;
    friend type get(DnsAccess tag);
};

template struct AccessPrivate<DnsAccess, &SettingsAsync::_dns>;

class SettingsAsyncFixed : public SettingsAsync {
    sets::DnsWrapper &get_dns_ref() { return this->*get(DnsAccess{}); }
public:
    explicit SettingsAsyncFixed(const String &title = "", GyverDB *db = nullptr) : SettingsAsync(title, db) {}
    void stop_with_dns() {
        stop();
        get_dns_ref().stop();
    }
};
```
Соответственно вместо `SettingsAsync` надо использовать `SettingsAsyncFixed`, а также вместо метода `stop` - `stop_with_dns`.